### PR TITLE
Fix timediff.py

### DIFF
--- a/timediff.py
+++ b/timediff.py
@@ -7,7 +7,7 @@ Created on Thu Oct 24 22:42:50 2019
 
 import pyspark
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import col
+from pyspark.sql.functions import col, round
 from pyspark.sql.functions import to_timestamp, current_timestamp
 from pyspark.sql.types import StructType, StructField, StringType, IntegerType, LongType
 

--- a/timediff.py
+++ b/timediff.py
@@ -25,7 +25,7 @@ df = spark.createDataFrame(list( zip(dates)), schema=schema)
 
 df.withColumn('input_timestamp',to_timestamp(col('input_timestamp')))\
   .withColumn('current_timestamp', current_timestamp().alias('current_timestamp'))\
-  .withColumn('DiffInSeconds',current_timestamp().cast(LongType) - col('input_timestamp').cast(LongType))\
+  .withColumn('DiffInSeconds',current_timestamp().cast(LongType()) - col('input_timestamp').cast(LongType()))\
   .withColumn('DiffInMinutes',round(col('DiffInSeconds')/60))\
   .withColumn('DiffInHours',round(col('DiffInSeconds')/3600))\
   .withColumn('DiffInDays',round(col('DiffInSeconds')/24*3600))\


### PR DESCRIPTION
I found two problems in timediff.py. 
First I met the same problem as [Romeo Kienzler](https://stackoverflow.com/questions/40701122/unexpected-type-class-pyspark-sql-types-datatypesingleton-when-casting-to-i) when running timediff.py and found that PySpark SQL data types are no longer singletons(seems to be the case before 1.3).
Second is my interpreter seems to use built-in round function if I don't add `from pyspark.sql.functions import round`.
I have run the timediff.py in python 3.7.13 with pyspark 3.3.0 and spark 3.3.0, everything works fine.

```bash
+--------------------+--------------------+-------------+-------------+-----------+-------------+
|     input_timestamp|   current_timestamp|DiffInSeconds|DiffInMinutes|DiffInHours|   DiffInDays|
+--------------------+--------------------+-------------+-------------+-----------+-------------+
|2019-07-01 12:01:...|2022-07-04 15:24:...|     94965792|    1582763.0|    26379.0|1.42448688E10|
|2019-06-24 12:01:...|2022-07-04 15:24:...|     95570592|    1592843.0|    26547.0|1.43355888E10|
|2019-11-16 16:44:...|2022-07-04 15:24:...|     83025576|    1383760.0|    23063.0|1.24538364E10|
|2019-11-16 16:50:...|2022-07-04 15:24:...|     83025212|    1383754.0|    23063.0|1.24537818E10|
+--------------------+--------------------+-------------+-------------+-----------+-------------+

```