### PR TITLE
Fixed issue in comparison. 

### DIFF
--- a/pyspark-lit.py
+++ b/pyspark-lit.py
@@ -20,5 +20,5 @@ df2.show(truncate=False)
 
 
 from pyspark.sql.functions import when
-df3 = df2.withColumn("lit_value2", when(col("Salary") >=40000 & col("Salary") <= 50000,lit("100")).otherwise(lit("200")))
+df3 = df2.withColumn("lit_value2", when((col("Salary") >= 40000) & (col("Salary") <= 50000), lit("100")).otherwise(lit("200")))
 df3.show(truncate=False)


### PR DESCRIPTION
In PySpark, the logical operators & and | have higher precedence than comparison operators like >= and <=. As a result, the expression is being evaluated incorrectly.

